### PR TITLE
fix the onDocumentMouseMove  - check function is exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -10245,7 +10245,10 @@
 			// Start the event listener to pick up the tooltip 
 			if (tooltip && !pointer._onDocumentMouseMove) {
 				pointer._onDocumentMouseMove = function (e) {
-					pointer.onDocumentMouseMove(e);
+					if(pointer.onDocumentMouseMove){
+						pointer.onDocumentMouseMove(e);
+					}
+
 				};
 				addEvent(doc, 'mousemove', pointer._onDocumentMouseMove);
 			}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "commonjs-highcharts",
+  "name": "commonjs-highcharts-clicktale",
   "version": "4.0.3",
   "description": "Allows to require highcharts with webpack or browserify",
   "main": "index.js",


### PR DESCRIPTION
I currently having problem wihh pointer.onDocumentMouseMove(e); called hundreds of times (the moment mouse moved over graph) and failing with we error , because function doesn't exist on the object
The fix is just checking the function is exists before calling it.
